### PR TITLE
Fix bare-tree foliage + integrate weather snippet styling

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -34,6 +34,11 @@ export default defineConfig({
         'ez-tree-src': fileURLToPath(
           new URL('./node_modules/@dgreenheck/ez-tree/src/lib/index.js', import.meta.url),
         ),
+        // Same exports-gate bypass for the leaf textures we load ourselves
+        // (EZ-Tree's own eager loader doesn't fetch them under this setup).
+        'ez-tree-leaves': fileURLToPath(
+          new URL('./node_modules/@dgreenheck/ez-tree/src/lib/assets/leaves', import.meta.url),
+        ),
       },
     },
     build: {

--- a/public/assets/css/editorial.css
+++ b/public/assets/css/editorial.css
@@ -322,23 +322,40 @@ body::after {
   .tree-canvas-host { --forest-opacity: 0.35; }
 }
 
-/* Local weather snippet — auto-resolved Arlington, VA. Reads as a soft glassy
-   caption, not a control: no pointer affordance, no interactive styling. */
+/* Local weather snippet — auto-resolved Arlington, VA. Shares the identity
+   column's button geometry (pill, full-width, same font) and accent-colour
+   family so it sits naturally alongside the CTA / flip buttons — but stays a
+   soft tinted caption with no pointer affordance, so it never reads as a
+   control. */
 .local-weather-status {
-  display: inline-block;
-  max-width: 100%;
-  margin: 0;
+  display: flex;
+  align-items: center;
+  align-self: stretch;          /* match button width in the column */
+  margin-top: 0.25rem;
   font-family: var(--font-ui);
   font-size: var(--fs-body-sm);
-  line-height: 1.5;
-  color: var(--on-surface-variant);
-  background: rgba(255, 255, 255, 0.5);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  border: 1px solid rgba(255, 255, 255, 0.65);
-  border-radius: var(--r-lg);
-  padding: 0.5rem 0.85rem;
-  box-shadow: var(--shadow-soft);
+  font-weight: 500;
+  line-height: 1.45;
+  color: var(--primary);
+  background: linear-gradient(135deg, rgba(36, 128, 253, 0.10), rgba(34, 209, 255, 0.10));
+  border: 1px solid rgba(36, 128, 253, 0.18);
+  border-radius: var(--r-pill);
+  padding: 0.7rem 1.1rem;
+  box-shadow: 0 4px 14px rgba(36, 128, 253, 0.10);
+}
+.local-weather-status::before {
+  /* Small location glyph keeps it warm + clearly informational, not clickable */
+  content: "";
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+  margin-right: 0.55rem;
+  background: currentColor;
+  -webkit-mask: center / contain no-repeat
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 2a7 7 0 0 0-7 7c0 5 7 13 7 13s7-8 7-13a7 7 0 0 0-7-7zm0 9.5A2.5 2.5 0 1 1 12 6.5a2.5 2.5 0 0 1 0 5z'/%3E%3C/svg%3E");
+  mask: center / contain no-repeat
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 2a7 7 0 0 0-7 7c0 5 7 13 7 13s7-8 7-13a7 7 0 0 0-7-7zm0 9.5A2.5 2.5 0 1 1 12 6.5a2.5 2.5 0 0 1 0 5z'/%3E%3C/svg%3E");
+  opacity: 0.85;
 }
 
 /* Quick flip toggle in nav */

--- a/src/ez-tree-leaves.d.ts
+++ b/src/ez-tree-leaves.d.ts
@@ -1,0 +1,6 @@
+// The `ez-tree-leaves` alias (astro.config.mjs) resolves to EZ-Tree's leaf
+// texture directory. Declare the PNG imports as URL strings.
+declare module 'ez-tree-leaves/*.png' {
+  const url: string;
+  export default url;
+}

--- a/src/scripts/forest.ts
+++ b/src/scripts/forest.ts
@@ -20,6 +20,15 @@ import * as THREE from 'three';
 // base64-inlines every bark/leaf texture into a 3.9 MB blob.
 import { Tree, TreePreset } from 'ez-tree-src';
 
+// Import the leaf billboard textures directly. EZ-Tree's own eager texture
+// loader doesn't fire a fetch under this bundling setup (leaves came back
+// with an empty .image → invisible foliage), so we load them ourselves and
+// assign m.map explicitly per tree.
+import ashLeafUrl from 'ez-tree-leaves/ash_color.png';
+import aspenLeafUrl from 'ez-tree-leaves/aspen_color.png';
+import oakLeafUrl from 'ez-tree-leaves/oak_color.png';
+import pineLeafUrl from 'ez-tree-leaves/pine_color.png';
+
 // Internal weather modes the forest understands. The weather driver maps
 // real conditions onto these; unknown modes fall back to 'sunny'.
 type WeatherMode =
@@ -146,6 +155,28 @@ export function initForest(host: HTMLElement): void {
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   host.appendChild(renderer.domElement);
 
+  // ── Leaf textures (loaded ourselves; see import note above) ────────
+  // Astro/Vite resolves image imports to a metadata object ({ src, width, … }),
+  // not a bare string — so read `.src` (falling back to the value itself).
+  const urlOf = (v: any): string => (typeof v === 'string' ? v : v?.src ?? '');
+  const texLoader = new THREE.TextureLoader();
+  const LEAF_URL: Record<string, string> = {
+    ash: urlOf(ashLeafUrl),
+    aspen: urlOf(aspenLeafUrl),
+    oak: urlOf(oakLeafUrl),
+    pine: urlOf(pineLeafUrl),
+  };
+  const leafTexCache: Record<string, THREE.Texture> = {};
+  function leafTexture(type: string): THREE.Texture {
+    const key = LEAF_URL[type] ? type : 'oak';
+    if (!leafTexCache[key]) {
+      const t = texLoader.load(LEAF_URL[key], () => renderOnce());
+      t.colorSpace = THREE.SRGBColorSpace;
+      leafTexCache[key] = t;
+    }
+    return leafTexCache[key];
+  }
+
   // Recover gracefully if the GPU drops the context.
   renderer.domElement.addEventListener('webglcontextlost', (e) => {
     e.preventDefault();
@@ -223,12 +254,13 @@ export function initForest(host: HTMLElement): void {
     low: { foreground: 2, midground: 5, background: 3 },
   };
 
-  // Warm, non-grey bark hues + leaf colour variance. Background trees get
-  // desaturated/cooler so depth reads clearly.
+  // Warm, non-grey bark hues + vivid summer-leaf colour variance. Background
+  // trees get slightly cooler/softer greens so depth still reads clearly, but
+  // they stay leafy (not bare).
   const BARK_HUES = [0x6b4f34, 0x7a5a3c, 0x5e4a39, 0x836547, 0x6f5034];
-  const LEAF_HUES = [0x4e7a3a, 0x5f8f42, 0x6fa04b, 0x789a3f, 0x86a94e, 0x57863c];
+  const LEAF_HUES = [0x6cb33f, 0x7cc24a, 0x86c84f, 0x9bd45c, 0x5fa83a, 0x8ec64d];
   const BARK_BG = [0x5a5246, 0x615747, 0x554f44];
-  const LEAF_BG = [0x55704a, 0x5e7850, 0x647d57];
+  const LEAF_BG = [0x6a9c4e, 0x74a657, 0x7fae5e];
 
   const rng = mulberry32(20260606);
   const pick = <T>(arr: T[]) => arr[Math.floor(rng() * arr.length)];
@@ -256,6 +288,7 @@ export function initForest(host: HTMLElement): void {
     const leafPool = band === 'background' ? LEAF_BG : LEAF_HUES;
     const barkColor = new THREE.Color(pick(barkPool));
     const leafColor = new THREE.Color(pick(leafPool));
+    const leafType = tree.options?.leaves?.type ?? 'oak';
     // Slight per-tree value jitter so neighbours differ.
     const jitter = 0.9 + rng() * 0.2;
     barkColor.multiplyScalar(jitter);
@@ -264,15 +297,21 @@ export function initForest(host: HTMLElement): void {
       if (!mesh.isMesh || !mesh.material) return;
       const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
       mats.forEach((m: any) => {
-        // Leaf materials are typically transparent/alpha-tested billboards;
-        // bark materials are opaque. Tint accordingly, then add wind.
-        if (m.transparent || m.alphaTest > 0) {
+        // EZ-Tree names the leaf material 'leaves'. Its textured billboard
+        // shader lives in its OWN onBeforeCompile (with built-in sway), so we
+        // must NOT overwrite it — only retint + reassign a real loaded map.
+        const isLeaf = m.name === 'leaves' || m.alphaTest > 0;
+        if (isLeaf) {
+          // EZ-Tree's eager loader leaves m.map with no image under our
+          // bundling, so assign our own loaded leaf texture explicitly.
+          m.map = leafTexture(leafType);
           if (m.color) m.color.copy(leafColor);
+          m.needsUpdate = true;
         } else {
           if (m.color) m.color.copy(barkColor);
           if ('roughness' in m) m.roughness = 0.8 + rng() * 0.2;
+          applyWind(m); // trunk/branch sway only
         }
-        applyWind(m);
       });
     });
   }
@@ -285,6 +324,13 @@ export function initForest(host: HTMLElement): void {
       tree.options.seed = Math.floor(rng() * 100000);
       tree.options.bark.textured = false;
       tree.options.bark.flatShading = true;
+      // Push foliage forward: bigger, denser leaf billboards so the canopy
+      // reads as a leafy summer tree rather than a bare branch skeleton.
+      if (tree.options.leaves) {
+        tree.options.leaves.size = (tree.options.leaves.size ?? 2.5) * 1.6;
+        tree.options.leaves.count = Math.round((tree.options.leaves.count ?? 12) * 1.5);
+        tree.options.leaves.alphaTest = 0.3; // keep soft leaf edges, less harsh cutout
+      }
       tree.generate();
 
       // Small scales; smaller still in the background. Vary per-tree.
@@ -307,6 +353,7 @@ export function initForest(host: HTMLElement): void {
   buildBand('background', counts.background);
   buildBand('midground', counts.midground);
   buildBand('foreground', counts.foreground);
+
 
   // ── Weather atmosphere (cheap material/uniform update + one render) ─
   function normalizeMode(mode: string): WeatherMode {


### PR DESCRIPTION
Foliage (the "creepy bare forest"): EZ-Tree's eager leaf-texture loader never fired a fetch under our bundling, so every leaf material had an empty .image and the alpha-tested billboards rendered invisible — leaving only bark skeletons. Two compounding bugs fixed:
- applyWind() was overwriting the leaf material's own onBeforeCompile (its billboard shader). Now only bark gets our trunk-sway; the leaf shader is left intact.
- Load the 4 leaf textures ourselves (Vite alias `ez-tree-leaves`) and assign m.map explicitly. Astro resolves image imports to a metadata object, so read `.src` (the bare object coerced to "[object Object]" → 404). Leaf PNGs now load 200 and foliage renders. Also bumped leaf size/count and brightened the summer-green leaf palette so the canopy reads clearly.

Weather snippet: restyle `.local-weather-status` to share the identity-column buttons' pill geometry, full-width sizing, font, and accent-colour family (with a location-pin glyph) so it sits naturally beside the "Get in touch" / flip buttons — while staying a soft tinted caption, not a control.

Verified headless: leaf textures load (1024² maps, 200s), forest renders, snippet shows live Arlington weather, 0 console errors, all 10 routes 200.