### PR TITLE
Add full-screen landing hero above the flip-card work

### DIFF
--- a/public/assets/css/editorial.css
+++ b/public/assets/css/editorial.css
@@ -281,9 +281,12 @@ body::after {
 }
 
 /* Ambient forest background — fixed full viewport, behind all content.
-   Tweak `--forest-opacity` below to dial down/up the visual presence. */
+   Tweak `--forest-opacity` below to dial down/up the visual presence.
+   On the landing hero the forest is faint (gives the WebGL scene time to
+   load, keeps the intro clean); once the user scrolls toward the work it
+   becomes more present (body.scrolled-past-hero, set by JS). */
 .tree-canvas-host {
-  --forest-opacity: 0.48;
+  --forest-opacity: 0.16;
   position: fixed;
   inset: 0;
   width: 100vw;
@@ -292,10 +295,12 @@ body::after {
   z-index: -1;             /* sits below content & nav, above body bloom (-3) and weather-bg (-2) */
   pointer-events: none;
   opacity: var(--forest-opacity);
+  transition: opacity 0.8s ease;
   /* Soft centre-fade: forest detail lives at the edges, reading zone stays clean */
   mask-image: radial-gradient(ellipse 58% 78% at 52% 50%, rgba(0,0,0,0.10) 0%, rgba(0,0,0,0.42) 42%, rgba(0,0,0,0.88) 68%, black 100%);
   -webkit-mask-image: radial-gradient(ellipse 58% 78% at 52% 50%, rgba(0,0,0,0.10) 0%, rgba(0,0,0,0.42) 42%, rgba(0,0,0,0.88) 68%, black 100%);
 }
+body.scrolled-past-hero .tree-canvas-host { --forest-opacity: 0.48; }
 .tree-canvas-host canvas {
   display: block;
   width: 100% !important;
@@ -312,14 +317,126 @@ body::after {
 }
 
 @media (max-width: 720px) {
+  body.scrolled-past-hero .tree-canvas-host { --forest-opacity: 0.38; }
   .tree-canvas-host {
-    --forest-opacity: 0.38;
     mask-image: none;
     -webkit-mask-image: none;
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .tree-canvas-host { --forest-opacity: 0.35; }
+  body.scrolled-past-hero .tree-canvas-host { --forest-opacity: 0.32; }
+}
+
+/* ==========================================================================
+   Landing hero — full-screen intro above the flippable work shell
+   ========================================================================== */
+
+.hero-intro {
+  position: relative;
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: calc(var(--nav-height) + 1rem) var(--gutter) 2rem;
+  text-align: center;
+}
+
+.hero-intro-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  /* Slight upward bias so the scroll cue has room below */
+  margin-top: -2rem;
+  max-width: 36rem;
+}
+
+.hero-portrait {
+  width: clamp(150px, 22vw, 260px);
+  height: clamp(150px, 22vw, 260px);
+  border-radius: 50%;
+  object-fit: cover;
+  border: 5px solid white;
+  box-shadow: 0 16px 48px rgba(36, 128, 253, 0.22);
+}
+
+.hero-name {
+  font-family: var(--font-sans);
+  font-size: clamp(2rem, 1.4rem + 2.6vw, 3rem);
+  font-weight: 800;
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+  color: var(--text-strong);
+  margin: 0;
+}
+.hero-name .burmese {
+  display: block;
+  font-size: 0.42em;
+  font-weight: 400;
+  color: var(--text-body);
+  margin-top: 0.5rem;
+  letter-spacing: 0;
+}
+/* The weather line inside the hero name uses the existing
+   .identity-weather-line typography (caption under the Burmese). */
+
+.hero-socials {
+  display: flex;
+  gap: 0.6rem;
+  margin: 0.25rem 0 0;
+  padding: 0;
+  list-style: none;
+  justify-content: center;
+}
+.hero-socials a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: white;
+  color: var(--on-surface-variant);
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+.hero-socials a:hover {
+  color: var(--primary);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lift);
+}
+.hero-socials svg { width: 20px; height: 20px; }
+
+/* Scroll cue */
+.hero-scroll-cue {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 1.5rem;
+  color: var(--on-surface-variant);
+  text-decoration: none;
+  font-family: var(--font-ui);
+  font-size: var(--fs-label-caps);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+.hero-scroll-cue:hover { color: var(--primary); }
+.hero-scroll-cue svg {
+  width: 26px;
+  height: 26px;
+  animation: scroll-bounce 1.8s ease-in-out infinite;
+}
+@keyframes scroll-bounce {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(6px); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .hero-scroll-cue svg { animation: none; }
 }
 
 /* Local weather line — a subtle secondary identity caption that sits under
@@ -421,6 +538,22 @@ body[data-face="back"] .flip-toggle svg { transform: rotate(180deg); }
 }
 .identity-col::-webkit-scrollbar { width: 4px; }
 .identity-col::-webkit-scrollbar-thumb { background: rgba(0, 89, 187, 0.2); border-radius: 2px; }
+
+/* Slim variant — identity now lives in the hero; this column carries only the
+   flip controls, centred vertically beside the card. */
+.identity-col--slim {
+  justify-content: center;
+  align-items: stretch;
+  gap: 0.85rem;
+}
+.identity-col-eyebrow {
+  font-family: var(--font-sans);
+  font-weight: 800;
+  font-size: 1.0625rem;
+  letter-spacing: -0.01em;
+  color: var(--text-strong);
+  margin: 0 0 0.25rem;
+}
 
 .identity-portrait {
   width: clamp(120px, 18vw, 160px);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,26 +27,22 @@ import Base from '../layouts/Base.astro';
 <div class="tree-canvas-host" id="tree-canvas-host" aria-hidden="true"></div>
 
 <!-- ─────────────────────────────────────────────────────────────────────
-     Shell: Persistent identity column + Flippable content card
+     Landing hero — full-screen intro. Scroll down to reach the work.
      ───────────────────────────────────────────────────────────────────── -->
-<div class="editorial-shell">
-
-  <!-- Identity column (left, persistent) -->
-  <aside class="identity-col" aria-label="About me">
-    <img class="identity-portrait"
+<section class="hero-intro" aria-label="Introduction">
+  <div class="hero-intro-inner">
+    <img class="hero-portrait"
          src="/assets/images/about.jpg"
          alt="Kaung Thiha"
          loading="eager"
-         width="160" height="160">
-    <h1 class="identity-name">
+         width="260" height="260">
+    <h1 class="hero-name">
       I'm Kaung
       <span class="burmese">(ကောင်းသီဟ)</span>
       <span class="identity-weather-line local-weather-status" aria-live="polite">Checking the weather in Arlington, Virginia…</span>
-      <span class="blurb"></span>
     </h1>
-    <p class="identity-bio"></p>
 
-    <ul class="identity-socials">
+    <ul class="hero-socials">
       <li>
         <a href="https://www.linkedin.com/in/kaungthiha/" target="_blank" rel="noopener" aria-label="LinkedIn">
           <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
@@ -63,7 +59,26 @@ import Base from '../layouts/Base.astro';
       </li>
     </ul>
 
-    <!-- Primary flip CTA — desktop, sits above mood selector -->
+    <!-- Scroll cue → jumps to the work below -->
+    <a class="hero-scroll-cue" href="#portfolio-content" aria-label="Scroll to the work">
+      <span class="hero-scroll-label">the work</span>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14M19 12l-7 7-7-7"/></svg>
+    </a>
+  </div>
+</section>
+
+<!-- ─────────────────────────────────────────────────────────────────────
+     Portfolio content — the existing flippable card shell, below the hero.
+     Identity (portrait/name/weather) now lives in the hero; this column
+     keeps only the flip controls.
+     ───────────────────────────────────────────────────────────────────── -->
+<div class="editorial-shell" id="portfolio-content">
+
+  <!-- Slim identity column — flip controls only -->
+  <aside class="identity-col identity-col--slim" aria-label="View controls">
+    <p class="identity-col-eyebrow">Kaung Thiha</p>
+
+    <!-- Primary flip CTA — desktop -->
     <button class="identity-flip" type="button" id="flip-toggle-primary" data-face-label="front" aria-label="See the person behind the work" aria-pressed="false">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 12a9 9 0 0 1 15.5-6.3M21 4v5h-5M21 12a9 9 0 0 1-15.5 6.3M3 20v-5h5"/></svg>
       Me!
@@ -524,18 +539,36 @@ import Base from '../layouts/Base.astro';
       }
     }
 
+    const heroEl    = document.querySelector('.hero-intro');
+    const contentEl = document.getElementById('portfolio-content');
+
+    // True while the landing hero still fills (most of) the viewport.
+    function onHero() {
+      return heroEl ? heroEl.getBoundingClientRect().bottom > window.innerHeight * 0.5 : false;
+    }
+
     function navigate(target) {
       const route = ROUTE[target];
       if (!route) return;
       const needsFlip = body.dataset.face !== route.face;
       navLinks.forEach(l => l.classList.toggle('is-active', l.dataset.navTarget === target));
 
-      if (needsFlip) {
-        applyFace(route.face);
-        setTimeout(() => scrollToSubsection(route.section), 620);
-      } else {
-        scrollToSubsection(route.section);
+      // From the landing hero, a nav click should first bring the work into
+      // view, then flip/scroll to the right subsection.
+      const wasOnHero = onHero();
+      if (wasOnHero && contentEl) {
+        contentEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
       }
+      const flipDelay = wasOnHero ? 650 : 0;
+
+      setTimeout(() => {
+        if (needsFlip) {
+          applyFace(route.face);
+          setTimeout(() => scrollToSubsection(route.section), 620);
+        } else {
+          scrollToSubsection(route.section);
+        }
+      }, flipDelay);
     }
 
     navLinks.forEach(l => {
@@ -560,6 +593,29 @@ import Base from '../layouts/Base.astro';
 
     applyFace('front');
     navLinks.forEach(l => l.classList.toggle('is-active', l.dataset.navTarget === 'tools'));
+  }());
+
+  // ── Scroll flow: hero → work ────────────────────────────────────────
+  (function () {
+    const hero = document.querySelector('.hero-intro');
+    if (!hero) return;
+
+    // Toggle a body class once the user scrolls past most of the hero, so the
+    // forest background fades in over the work (see editorial.css).
+    let ticking = false;
+    function update() {
+      ticking = false;
+      const past = hero.getBoundingClientRect().bottom < window.innerHeight * 0.6;
+      document.body.classList.toggle('scrolled-past-hero', past);
+    }
+    window.addEventListener('scroll', () => {
+      if (!ticking) { ticking = true; requestAnimationFrame(update); }
+    }, { passive: true });
+    update();
+
+    // The scroll cue is a normal anchor (#portfolio-content) — smooth scroll is
+    // handled by CSS scroll-behavior. Nothing else needed; keyboard activation
+    // works because it's an <a href>.
   }());
 </script>
 


### PR DESCRIPTION
New flow: a clean centred landing hero, scroll down to the existing flippable work, scroll back up to the landing. The flip system (faces, Me!/Back-to-work buttons, mobile Work/Context segmented control, nav routing, project modal, image lightbox) is fully preserved.

- index.astro: prepend a full-screen .hero-intro (portrait, "I'm Kaung" + Burmese, the Arlington weather line, LinkedIn/Spotify, and a bouncing "the work" scroll cue anchored to #portfolio-content). The identity column below is slimmed to just the flip controls (identity now lives only in the hero, so it isn't repeated right after it). The weather line moved into the hero name block; weather.js still targets .local-weather-status, so it keeps updating. Nav clicks from the hero first scroll the page into the work, then flip/scroll to the right subsection.
- editorial.css: hero, portrait, name, socials, and scroll-cue styles; the forest background is faint on the landing and fades in via body.scrolled-past-hero once the user scrolls toward the work (gives the WebGL scene time to load and keeps the intro clean). Scroll-cue bounce respects prefers-reduced-motion. The page is now vertically scrollable: hero 100vh, then the content shell at 100dvh.

Verified headless: landing shows only the hero (work below the fold), scrolling reveals the flip card and fades the forest in, the flip + nav + project modal still work, the hero weather line updates with live Arlington weather, no horizontal overflow on mobile (390px), reduced-motion static, all routes 200, 0 console errors.