### PR TITLE
De-pill Tools buttons; align attendance tracker with portfolio style

### DIFF
--- a/public/assets/css/editorial.css
+++ b/public/assets/css/editorial.css
@@ -910,6 +910,20 @@ body[data-face="back"] .card-flipper {
 .tool-link svg { width: 14px; height: 14px; transition: transform 0.2s ease; }
 .tool-link:hover svg { transform: translateX(3px); }
 
+/* Tools-card links: plain blue text (no pill), matching the project CTA.
+   The base .tool-link pill is kept for the project-modal footer action. */
+.tool-card .tool-link {
+  background: none;
+  color: var(--primary);
+  padding: 0;
+  border-radius: 0;
+}
+.tool-card .tool-link:hover {
+  background: none;
+  color: var(--primary-container);
+  transform: none;
+}
+
 /* ==========================================================================
    Detailed About + Skills (back face)
    ========================================================================== */

--- a/public/tools/attendance-tracker/index.html
+++ b/public/tools/attendance-tracker/index.html
@@ -6,6 +6,43 @@
 <link rel="icon" href="/favicon.ico">
 <title>Capital One Attendance Tracker | KT's Portfolio</title>
 <meta name="description" content="Track office attendance across rolling 13-week periods. Calculate prorated requirements, mark attendance, and export as JSON.">
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+  /* Align the tracker with the portfolio's frost/white + blue-accent look.
+     Visual only — no layout or functionality changes. */
+  :root {
+    --kt-primary: #0059bb;
+    --kt-accent-grad: linear-gradient(135deg, #2480FD 0%, #26A1FF 50%, #22D1FF 100%);
+  }
+  body {
+    margin: 0;
+    /* Soft sky → white wash, matching the portfolio background. */
+    background: linear-gradient(180deg, #D0E5FC 0%, #f5faff 55%, #f5faff 100%);
+    background-attachment: fixed;
+    min-height: 100vh;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    color: #171D27;
+  }
+  /* Headings use the portfolio display face. */
+  h1, h2, h3 { font-family: 'Plus Jakarta Sans', -apple-system, sans-serif; letter-spacing: -0.01em; }
+
+  /* Calmer, more even card shadows than the heavy default drop-shadows. */
+  [class*="tw-shadow-md"], [class*="tw-shadow-lg"] { box-shadow: 0 8px 32px rgba(36, 128, 253, 0.08) !important; }
+  [class*="tw-shadow-sm"] { box-shadow: 0 4px 24px rgba(36, 128, 253, 0.06) !important; }
+  [class*="tw-shadow-2xl"] { box-shadow: 0 20px 56px rgba(36, 128, 253, 0.18) !important; }
+
+  /* The blue→cyan gradient becomes the portfolio's softer accent gradient. */
+  [class*="tw-from-[#0066FF]"][class*="tw-to-[#00D4FF]"] { background-image: var(--kt-accent-grad) !important; }
+
+  /* Solid-blue accents → the portfolio primary. */
+  [class*="tw-text-[#0066FF]"] { color: var(--kt-primary) !important; }
+  [class*="tw-border-[#0066FF]"] { border-color: var(--kt-primary) !important; }
+
+  /* Calmer disclaimer banner (cream/orange → soft amber that still reads as a note). */
+  [class*="tw-bg-[#FFF8E1]"] { background-color: #fdf6e3 !important; }
+</style>
 </head>
 <body>
 <div id="attendance-tracker-root"></div>


### PR DESCRIPTION
- Tools section: the three "Open Tracker / Open Tool" buttons now render as plain blue text (no blue pill), matching the formal-work project CTA. Scoped to .tool-card so the project-modal footer action keeps its pill.
- Attendance tracker: visual polish to align with the portfolio's frost/white
  + blue-accent look (no functionality or layout changes). Adds the portfolio fonts + a soft sky->white page background, swaps the blue->cyan gradient for the portfolio accent gradient, evens out the card shadows, and calms the disclaimer banner. All done via a single injected <style> block + a few attribute-targeted overrides — the React logic is untouched.

Verified headless: tools links are transparent-bg blue text while the modal footer link stays a pill; the tracker mounts, renders its 31 calendar cells, and shows the new background, 0 console errors.